### PR TITLE
feat: add visually hidden descriptions to bare icon links

### DIFF
--- a/src/components/base/SideBar.vue
+++ b/src/components/base/SideBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sidebar-container" :class="[collapsed ? 'p-2' : 'p-4']">
+  <div :class="[collapsed ? 'p-2' : 'p-4']">
     <div class="has-text-right">
       <button type="button" class="button bars px-0" @click="toggle">
         <i v-if="!collapsed" class="fas fa-times" />
@@ -16,12 +16,14 @@
           <router-link to="/">
             <i class="fas fa-home mr-1" />
             <span v-if="!collapsed">Home</span>
+            <VisuallyHidden v-else>Home</VisuallyHidden>
           </router-link>
         </li>
         <li>
           <router-link to="/about">
             <i class="fas fa-info-circle mr-1" />
             <span v-if="!collapsed">About</span>
+            <VisuallyHidden v-else>About</VisuallyHidden>
           </router-link>
         </li>
       </ul>
@@ -71,16 +73,14 @@
       <ul class="menu-list">
         <li v-for="(item, i) in RESOURCES" :key="i">
           <a :href="item.link">
-            <span v-if="!collapsed">
+            <div v-if="!collapsed" class="is-flex is-align-items-center">
               <i class="fas mr-1" :class="item.icon" />
-              <span>{{ item.title }}</span>
-            </span>
-            <span v-else>
-              <abbr :title="item.title" class="collapsed-flex-item">
-                <i class="fas mr-1" :class="item.icon" />
-                <span>{{ item.initials }}</span>
-              </abbr>
-            </span>
+              <div>{{ item.title }}</div>
+            </div>
+            <abbr v-else :title="item.title" class="collapsed-flex-item">
+              <i class="fas mr-1" :class="item.icon" />
+              <span>{{ item.initials }}</span>
+            </abbr>
           </a>
         </li>
       </ul>
@@ -90,6 +90,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+
+import VisuallyHidden from "@/components/base/VisuallyHidden.vue";
 
 const emit = defineEmits(["toggle"]);
 
@@ -149,7 +151,6 @@ const activeRoute = computed(() => {
 
 <style lang="scss" scoped>
 @import "@/assets/styles/main.scss";
-
 .not-allowed-cursor {
   cursor: not-allowed;
 }
@@ -165,5 +166,10 @@ const activeRoute = computed(() => {
   span {
     font-size: 0.6rem;
   }
+}
+
+.menu-list a {
+  padding-right: 0;
+  padding-left: 0.5em;
 }
 </style>

--- a/src/components/base/VisuallyHidden.vue
+++ b/src/components/base/VisuallyHidden.vue
@@ -1,0 +1,45 @@
+<template>
+  <span :class="[forceShow || 'visually-hidden']">
+    <slot></slot>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, ref } from "vue";
+
+const forceShow = ref(false);
+
+if (import.meta.env.DEV) {
+  const handleKeyDown = (ev) => {
+    if (ev.key === "Alt") {
+      forceShow.value = true;
+    }
+  };
+  const handleKeyUp = (ev) => {
+    if (ev.key === "Alt") {
+      forceShow.value = false;
+    }
+  };
+  window.addEventListener("keydown", handleKeyDown);
+  window.addEventListener("keyup", handleKeyUp);
+
+  onUnmounted(() => {
+    window.removeEventListener("keydown", handleKeyDown);
+    window.removeEventListener("keyup", handleKeyUp);
+  });
+}
+</script>
+
+<style scoped>
+.visually-hidden {
+  display: inline-block;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1;
+  width: 1;
+  margin: -1;
+  padding: 0;
+  border: 0;
+}
+</style>

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -51,7 +51,7 @@ main {
 .dashboard-grid {
   background-image: linear-gradient(to top left, whitesmoke, white);
   display: grid;
-  grid-template-columns: 2fr 10fr;
+  grid-template-columns: minmax(13rem, 2fr) 10fr;
   grid-template-areas: "sidebar main";
   @include mobile {
     grid-template-columns: 100vw;

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -29,13 +29,11 @@
             Project SIGNAL is a collaboration between the
             <a href="https://health.ri.gov/"
               >Rhode Island Department of Health</a
-            >
-            ; the People, Place, and Health Collective in the Department of
+            >; the People, Place, and Health Collective in the Department of
             Epidemiology at the
             <a href="https://www.brown.edu/academics/public-health/home">
               Brown University School of Public Health</a
-            >
-            ; and the
+            >; and the
             <a href="https://ccv.brown.edu/"
               >Center for Computation and Visualization</a
             >. The People, Place, and Health Collective conducts research to
@@ -52,12 +50,15 @@
           <p>
             <a class="pl-4" href="https://github.com/pph-collective">
               <i class="fab fa-github"></i>
+              <VisuallyHidden>GitHub</VisuallyHidden>
             </a>
             <a class="pl-4" href="https://twitter.com/pph_collective">
               <i class="fab fa-twitter"></i>
+              <VisuallyHidden>Twitter</VisuallyHidden>
             </a>
             <a class="pl-4" href="https://www.instagram.com/pph_collective">
               <i class="fab fa-instagram"></i>
+              <VisuallyHidden>Instagram</VisuallyHidden>
             </a>
           </p>
         </div>
@@ -91,4 +92,5 @@
 <script setup lang="ts">
 import DashboardLayout from "@/layouts/dashboard.vue";
 import DashboardCard from "@/components/base/DashboardCard.vue";
+import VisuallyHidden from "@/components/base/VisuallyHidden.vue";
 </script>


### PR DESCRIPTION
* Add Visually hidden component
  * When in dev mode, can hold down Alt/Option to see the labels
* Use VisuallyHidden component to describe icon links
* minor tweaks to about prose (semicolons were being detached from the preceding word)
* minor tweaks to sidebar styling