### PR TITLE
fix: large font styling and chart creep

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -8,22 +8,9 @@ $dark: #434343;
 $menu-item-active-background-color: $primary;
 $family-sans-serif: "avenir", "Montserrat", BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 $family-secondary: "Sinhala MN", "Assistant", $family-sans-serif;
+
 @import "../../../node_modules/bulma/bulma.sass";
 
-// widely used utility classes
-.is-flex-column {
-  @extend .is-flex;
-  flex-direction: column;
-}
-
-/* used by download form and explore form fields */
-.control-item {
-  @extend .py-2;
-  @extend .px-2;
-  width: 100%;
-  flex-grow: 1;
-  min-width: 250px;
-}
 
 // have buttons wrap lines - this is overwriting bulma
 .button {
@@ -35,16 +22,17 @@ $family-secondary: "Sinhala MN", "Assistant", $family-sans-serif;
 // used in vega lite svgs
 text {
   font-family: $family-sans-serif;
-  font-size: 0.7rem;
 }
 
 #vg-tooltip-element.vg-tooltip {
   white-space: pre-wrap;
   color: #333333;
   font-family: $family-sans-serif;
+  font-size: 0.7rem;
   h2 {
     margin-bottom: 0.2em;
     font-weight: bold;
+    font-size: 1rem;
   }
   table {
     tr {

--- a/src/components/base/DashboardCard.vue
+++ b/src/components/base/DashboardCard.vue
@@ -61,28 +61,35 @@ withDefaults(defineProps<Props>(), {
 
 .is-one-third {
   grid-column-start: span 2;
-  @include mobile {
+  @include touch {
     grid-column-start: span 1;
   }
 }
 .is-half {
   grid-column-start: span 3;
+  @include touch {
+    grid-column-start: span 1;
+  }
+}
+.is-two-thirds {
+  grid-column-start: span 4;
+  @include tablet-only {
+    grid-column-start: span 2;
+  }
   @include mobile {
     grid-column-start: span 1;
   }
 }
 .is-full {
   grid-column-start: span 6;
+  @include tablet-only {
+    grid-column-start: span 2;
+  }
   @include mobile {
     grid-column-start: span 1;
   }
 }
-.is-two-thirds {
-  grid-column-start: span 4;
-  @include mobile {
-    grid-column-start: span 1;
-  }
-}
+
 .is-height-1 {
   grid-row-start: span 1;
 }

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -61,11 +61,13 @@ const activeStats = computed(() => {
   }
 });
 
+const remSize = parseFloat(getComputedStyle(document.documentElement).fontSize)
+
 const spec = computed(() => {
   return {
     $schema: "https://vega.github.io/schema/vega/v5.json",
     background: "transparent",
-    padding: { left: 5, top: 0, right: 5, bottom: 0 },
+    padding: { left: 0, top: 0, right: 0, bottom: -1 },
 
     data: [
       {
@@ -102,6 +104,7 @@ const spec = computed(() => {
         labelSeparation: 4,
         domain: false,
         ticks: false,
+        labelFontSize: remSize * 0.7,
       },
       {
         orient: "left",
@@ -112,6 +115,7 @@ const spec = computed(() => {
         labelFontWeight: 700,
         labelPadding: 5,
         offset: 1.5,
+        labelFontSize: remSize * 0.7,
       },
     ],
 
@@ -178,9 +182,10 @@ const spec = computed(() => {
             fill: { value: COLORS.dark },
             align: { value: "center" },
             baseline: { value: "middle" },
+            fontSize: { value: remSize * 0.7 },
             text: {
               signal:
-                "datum.datum.gap > 0 && datum.width > 60 ? datum.datum.gap + ' doses' : datum.datum.gap > 0 && datum.width > 25 ? datum.datum.gap : ''",
+                `datum.datum.gap > 0 && datum.width > ${remSize * 3.75} ? datum.datum.gap + ' doses' : datum.datum.gap > 0 && datum.width > ${remSize * 1.75} ? datum.datum.gap : ''`,
             },
           },
         },

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -89,6 +89,9 @@ main {
   justify-content: space-between;
   align-content: start;
   grid-auto-flow: row;
+  @include tablet-only {
+    grid-template-columns: repeat(2, 1fr);
+  }
   @include mobile {
     grid-template-columns: 100vw;
     column-gap: 0px;


### PR DESCRIPTION
* add a padding of -1 to the bottom of the gap chart (magically fixes things?)
* calculate how big a rem currently is, then use that in gap chart to set sizes instead of via css (this allows vega to have a better sense of the size of the chart)
* have the tooltip styling use rem
* add a tablet level layout in between desktop and mobile (this isn't pretty yet, but should be addressed in #69 )