### PR TITLE
fix: isolate stacking contexts so error page is always on top

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -19,6 +19,10 @@ $family-secondary: "Sinhala MN", "Assistant", $family-sans-serif;
   height: revert;
 }
 
+.is-isolated {
+  isolation: isolate;
+}
+
 // used in vega lite svgs
 text {
   font-family: $family-sans-serif;

--- a/src/components/base/ErrorPage.vue
+++ b/src/components/base/ErrorPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="error-container">
+  <main class="error-container is-isolated">
     <div class="error-content">
       <i class="fas fa-life-ring mr-2 has-text-danger" />
       <p>{{ message }}</p>

--- a/src/components/base/SuspenseComponent.vue
+++ b/src/components/base/SuspenseComponent.vue
@@ -1,5 +1,4 @@
 <template>
-  <ErrorPage v-if="errored" :message="errorMessage" @clear="errored = false" />
   <Suspense :key="$route.path">
     <slot />
 
@@ -7,6 +6,8 @@
       <LoadingSpinner :loading="true" />
     </template>
   </Suspense>
+
+  <ErrorPage v-if="errored" :message="errorMessage" @clear="errored = false" />
 </template>
 
 <script setup lang="ts">

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="[collapsed ? 'dashboard-grid-collapsed' : 'dashboard-grid']">
+  <div
+    :class="[collapsed ? 'dashboard-grid-collapsed' : 'dashboard-grid']"
+    class="is-isolated"
+  >
     <aside class="sidebar">
       <SideBar @toggle="collapsed = !collapsed" />
     </aside>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="is-isolated">
     <a class="logo-container" href="/">
       <span class="brand-title is-family-secondary">Project SIGNAL</span>
       <BaseLogo />

--- a/src/views/datasets/index.vue
+++ b/src/views/datasets/index.vue
@@ -1,11 +1,11 @@
 <template>
-  <DashboardLayout>
-    <router-view v-slot="{ Component }">
-      <SuspenseComponent :key="$route.path">
+  <router-view v-slot="{ Component }">
+    <SuspenseComponent :key="$route.path">
+      <DashboardLayout>
         <component :is="Component"></component>
-      </SuspenseComponent>
-    </router-view>
-  </DashboardLayout>
+      </DashboardLayout>
+    </SuspenseComponent>
+  </router-view>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
* Make sure the error page is always the last component in the markup (instead of relying on z-index)
* Isolate the stacking contexts for the pages so they don't bleed into each other
* Move the dashboard layout inside the router view to keep the stacking context of the error page separate from the cards