### PR TITLE
refactor: Gap Chart - 0 population --> not enough information

### DIFF
--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -129,10 +129,13 @@ const spec = computed(() => {
           },
           update: {
             opacity: { value: 0.9 },
-            tooltip: {
-              signal:
-                "{ title: datum.name, 'Percent Vaccinated': format(datum.pct, '.0%'), 'Doses to Close Gap': datum.gap}",
-            },
+            tooltip: [
+              {
+                signal:
+                  "{ title: datum.name, 'Percent Vaccinated': format(datum.pct, '.0%'), 'Doses to Close Gap': datum.gap}",
+                test: "datum.population > 0",
+              },
+            ],
           },
           hover: {
             opacity: { value: 1.0 },
@@ -159,13 +162,16 @@ const spec = computed(() => {
             fill: { value: "transparent" },
           },
           update: {
-            tooltip: {
-              signal: `datum.population > 0 ? {
+            tooltip: [
+              {
+                signal: `{
                 title: datum.name,
                 'Percent Vaccinated': format(datum.pct, '.0%'),
                 'Doses to Close Gap': datum.gap
-                } : ''`,
-            },
+                }`,
+                test: "datum.population > 0",
+              },
+            ],
           },
         },
       },

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -209,6 +209,6 @@ useVega({
   minHeight: ref(180),
   maxHeight: ref(1280),
   maxWidth: ref(1280),
-  includeActions: ref(true),
+  includeActions: ref(false),
 });
 </script>

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -160,11 +160,11 @@ const spec = computed(() => {
           },
           update: {
             tooltip: {
-              signal: `{
+              signal: `datum.population > 0 ? {
                 title: datum.name,
-                'Percent Vaccinated': datum.population > 0 ? format(datum.pct, '.0%') : '${NA_TEXT}',
-                'Doses to Close Gap': datum.population > 0 ? datum.gap : '${NA_TEXT}'
-                }`,
+                'Percent Vaccinated': format(datum.pct, '.0%'),
+                'Doses to Close Gap': datum.gap
+                } : ''`,
             },
           },
         },

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -125,7 +125,7 @@ const spec = computed(() => {
             },
             height: { scale: "yscale", band: 1 },
             fill: { value: COLORS.dark },
-            stroke: { value: COLORS.dark },
+            stroke: [{ value: COLORS.dark, test: `datum.population > 0` }],
           },
           update: {
             opacity: { value: 0.9 },
@@ -148,13 +148,13 @@ const spec = computed(() => {
             x: { scale: "xscale", field: "pct" },
             x2: {
               scale: "xscale",
-              value: `datum.population > 0 ? ${expected.value} : 0`,
+              value: expected.value,
             },
             yc: {
               signal: "scale('yscale', datum.name) + bandwidth('yscale') / 2",
             },
             height: { scale: "yscale", band: 1 },
-            stroke: { value: COLORS.dark },
+            stroke: [{ value: COLORS.dark, test: `datum.population > 0` }],
             strokeDash: { value: [1, 1] },
             fill: { value: "transparent" },
           },

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useVega } from "../../composables/useVega";
-import { COLORS, NA_TEXT } from "../../utils/constants";
+import { COLORS } from "../../utils/constants";
 
 interface Props {
   stats: Stat[];
@@ -186,7 +186,7 @@ const spec = computed(() => {
             fill: { value: COLORS.dark },
             baseline: { value: "middle" },
             text: {
-              signal: `datum.datum.population === 0 ? '${NA_TEXT}' : ''`,
+              signal: `datum.datum.population === 0 ? 'Not enough information' : ''`,
             },
           },
         },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,3 +15,5 @@ export const COLOR_SCALES = {
 };
 
 export const NULL_CLUSTER = { name: "", cluster_id: -1 };
+
+export const NA_TEXT = "Not enough information";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,5 +15,3 @@ export const COLOR_SCALES = {
 };
 
 export const NULL_CLUSTER = { name: "", cluster_id: -1 };
-
-export const NA_TEXT = "Not enough information";


### PR DESCRIPTION
- For the gap chart, say "Not enough information" if the population is 0

<img width="541" alt="Screen Shot 2022-04-20 at 5 15 02 PM" src="https://user-images.githubusercontent.com/5270855/164324259-d64678f1-c372-49fc-9176-755d9e03f0cf.png">



~Is the tooltip too awkward? Should there just be no tooltip?~
Tooltip removed -- previously [image](https://user-images.githubusercontent.com/5270855/164324261-7be20bc7-68e9-4f74-93d7-b63ac1d79e24.png)
