### PR TITLE
fix: use drop shadow on all cards instead of box shadow on each card

### DIFF
--- a/src/components/base/DashboardCard.vue
+++ b/src/components/base/DashboardCard.vue
@@ -37,8 +37,11 @@ withDefaults(defineProps<Props>(), {
 @import "@/assets/styles/main.scss";
 
 .dashboard-card {
-  @extend .box;
-  margin-bottom: 0 !important; /* overrides .box */
+  background-color: $box-background-color;
+  border-radius: $box-radius;
+  color: $box-color;
+  padding: $box-padding;
+  margin-bottom: 0;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -104,6 +104,10 @@ main {
   }
   max-width: 1600px;
   margin: auto;
+
+  filter: drop-shadow(0.25em 0.25em 0.25em rgba($scheme-invert, 0.1))
+    drop-shadow(0.05em 0.05em 0.05em rgba($scheme-invert, 0.02))
+    drop-shadow(0em 0em 0.1em rgba($scheme-invert, 0.05));
 }
 
 .main-header {


### PR DESCRIPTION
* I learned in css for js about shadow bleed when items with box shadow are close to each other and noticed we have that a little
* copy over the box params we use instead of extending box
* don't copy over the box-shadow on box
* put a drop-shadow filter behind all of dashboard content

Before:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/24885580/164551739-11e951ea-7878-46b1-ad58-dab15a7b840d.png">

After:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/24885580/164551772-f54bca69-9149-46c4-b992-d48a5e3b623d.png">

(it's really subtle... I know)
