### PR TITLE
fix: add population to the active stats, lost in merge

### DIFF
--- a/src/components/dashboard/GapByRace.vue
+++ b/src/components/dashboard/GapByRace.vue
@@ -58,11 +58,18 @@ const activeStats = computed(() => {
   );
   if (row) {
     // don't let a population be more than 100% vaccinated
-    return fieldData.value.map((f) => ({
-      name: f.name,
-      pct: Math.min(1, row[f.observedField] / row[f.populationField]),
-      gap: Math.max(0, row[f.expectedField] - row[f.observedField]),
-    }));
+    return fieldData.value.map((f) => {
+      const population = row[f.populationField];
+      return {
+        name: f.name,
+        pct:
+          population > 0
+            ? Math.min(1, row[f.observedField] / row[f.populationField])
+            : 0,
+        gap: Math.max(0, row[f.expectedField] - row[f.observedField]),
+        population,
+      };
+    });
   } else {
     return [];
   }


### PR DESCRIPTION
At our team meeting, Mary and I noticed that the not enough information on the gap chart wasn't displaying. It must have gotten lost in the great merge! All is well, here is the PR to fix it up ✨ 

<img width="798" alt="Screen Shot 2022-04-28 at 1 05 30 PM" src="https://user-images.githubusercontent.com/5270855/165806633-ac45473d-ff25-4260-81ab-68d107a80b75.png">
