### PR TITLE
fix: loading spinner containing block

### DIFF
--- a/src/components/base/DashboardCard.vue
+++ b/src/components/base/DashboardCard.vue
@@ -47,6 +47,10 @@ withDefaults(defineProps<Props>(), {
   justify-content: flex-start;
   align-items: flex-start;
   overflow-x: visible;
+
+  filter: drop-shadow(0.25em 0.25em 0.25em rgba($scheme-invert, 0.1))
+    drop-shadow(0.05em 0.05em 0.05em rgba($scheme-invert, 0.02))
+    drop-shadow(0em 0em 0.1em rgba($scheme-invert, 0.05));
 }
 
 .dashboard-card-header {

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -104,10 +104,6 @@ main {
   }
   max-width: 1600px;
   margin: auto;
-
-  filter: drop-shadow(0.25em 0.25em 0.25em rgba($scheme-invert, 0.1))
-    drop-shadow(0.05em 0.05em 0.05em rgba($scheme-invert, 0.02))
-    drop-shadow(0em 0em 0.1em rgba($scheme-invert, 0.05));
 }
 
 .main-header {

--- a/src/views/datasets/vaccine-gap/dashboard.vue
+++ b/src/views/datasets/vaccine-gap/dashboard.vue
@@ -44,8 +44,9 @@
       This map shows where there are gaps in vaccination. Darker areas show
       bigger gaps in vaccination among
       <strong>{{ controls.focusStat.name.toLowerCase() }}</strong
-      >. Areas with dashes mean there is not enough information. Select a community, click the <em>Zoom to Community</em> button, and
-      scroll down to learn more.
+      >. Areas with dashes mean there is not enough information. Select a
+      community, click the <em>Zoom to Community</em> button, and scroll down to
+      learn more.
     </template>
 
     <template #content>


### PR DESCRIPTION
Applying the `filter` to the dashboard layout caused the containing block of the loading spinner to change to just the dashboard instead of the viewport.  I've moved the filter to the dashboard cards instead and that keeps the containing block the viewport.