### PR TITLE
fix: safari date parsing

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -29,9 +29,13 @@ export const geoToTopo = (features, sphericalArea = 1e-9) => {
 // 2022-03-15 => March 15, 2022
 export const prettyDate = (date: string): string => {
   // Support for ISO 8601  differs in that date-only strings (e.g. "1970-01-01") are treated as UTC, not local.
-  // This hack, sets the time to the start of the day such that we get back the day we specified in the yyyy-mm-dd
-  // https://stackoverflow.com/questions/48351987/create-javascript-date-object-from-string-yyyy-mm-dd-in-local-timezone
-  return new Date(`${date} 00:00`).toLocaleDateString("en-US", {
+  // We split the date into its parts, so we can build a js Date with local time
+  const dateParts = date.split("-").map((p) => parseInt(p));
+  return new Date(
+    dateParts[0],
+    dateParts[1] - 1, // months are 0-indexed in js
+    dateParts[2]
+  ).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",


### PR DESCRIPTION
It turns out safari doesn't like bare times on a date string (it's always safari... 🤦), so this PR instead pulls out the date parts and reconstructs the date.