### PR TITLE
fix: zooming

### DIFF
--- a/src/components/dashboard/ColdMap.vue
+++ b/src/components/dashboard/ColdMap.vue
@@ -250,10 +250,8 @@ const emit = defineEmits(["new-active-cluster-id"]);
 watch(view, () => {
   if (view.value) {
     view.value.addSignalListener("activeGeography", (name, value) => {
-      if (value !== currentClusterId) {
-        currentClusterId = value;
-        emit("new-active-cluster-id", currentClusterId);
-      }
+      currentClusterId = value;
+      emit("new-active-cluster-id", currentClusterId);
     });
   }
 });

--- a/src/views/datasets/booster-gap/dashboard.vue
+++ b/src/views/datasets/booster-gap/dashboard.vue
@@ -274,9 +274,6 @@ useQueryParam({
 });
 
 const updateControls = (newControls) => {
-  // only update when the controls change to avoid a render loop
-  dashboardActiveCluster.value = activeCluster.value;
-
   // zoom back out, selections don't make sense with zoom in
   if (zoomed.value) {
     zoomed.value = false;
@@ -284,7 +281,7 @@ const updateControls = (newControls) => {
 
   // new town selected, unselect active cluster
   if (newControls.town !== controls.value.town) {
-    activeCluster.value = NULL_CLUSTER;
+    // activeCluster gets reset through useQueryParam, therefore we just need to update dashboardActiveCluster
     dashboardActiveCluster.value = NULL_CLUSTER;
   }
 
@@ -296,6 +293,7 @@ const updateControls = (newControls) => {
 
 const updateCluster = (newClusterId) => {
   activeCluster.value = clusterIdToCluster(newClusterId);
+  dashboardActiveCluster.value = activeCluster.value;
 };
 </script>
 

--- a/src/views/datasets/vaccine-gap/dashboard.vue
+++ b/src/views/datasets/vaccine-gap/dashboard.vue
@@ -273,9 +273,6 @@ useQueryParam({
 });
 
 const updateControls = (newControls) => {
-  // only update when the controls change to avoid a render loop
-  dashboardActiveCluster.value = activeCluster.value;
-
   // zoom back out, selections don't make sense with zoom in
   if (zoomed.value) {
     zoomed.value = false;
@@ -283,7 +280,7 @@ const updateControls = (newControls) => {
 
   // new town selected, unselect active cluster
   if (newControls.town !== controls.value.town) {
-    activeCluster.value = NULL_CLUSTER;
+    // activeCluster gets reset through useQueryParam, therefore we just need to update dashboardActiveCluster
     dashboardActiveCluster.value = NULL_CLUSTER;
   }
 
@@ -295,6 +292,7 @@ const updateControls = (newControls) => {
 
 const updateCluster = (newClusterId) => {
   activeCluster.value = clusterIdToCluster(newClusterId);
+  dashboardActiveCluster.value = activeCluster.value;
 };
 </script>
 


### PR DESCRIPTION
Steps to reproduce issue (on the signal website)
- Reload the page
- Click a cluster
- Use the dropdown to go to the cluster
- At this point it doesn't zoom in. Take a look at the url and you'll see that it doesn't seem to update

Th problem
The issue turns out to be that the url updated multiple times and overwrote changes to itself. 

This PR
- Reduces updating the active cluster twice multiple times which causes the url to update again
- Removes check if the activeGeometry the same in the coldmap. There was a problem with selecting geometry too which was weird... this solved that

closes #169 