### PR TITLE
Booster Gap Chart Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10467,6 +10467,7 @@
     },
     "node_modules/vega-embed/node_modules/yallist": {
       "version": "4.0.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -18453,7 +18454,8 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -38,7 +38,7 @@ const spec = computed(() => {
     scales: [
       {
         name: "xscale",
-        domain: [0, 1],
+        domain: [0, Math.min(props.expected * 1.25, 1)],
         range: "width",
       },
       {
@@ -52,6 +52,7 @@ const spec = computed(() => {
 
     axes: [
       {
+        title: "Percent Vaccinated",
         orient: "bottom",
         scale: "xscale",
         format: ".0%",
@@ -132,6 +133,13 @@ const spec = computed(() => {
                 test: "datum.population > 0",
               },
             ],
+            fill: { value: "transparent" },
+          },
+          hover: {
+            fill: { value: COLORS.info },
+          },
+          exit: {
+            fill: { value: "transparent" },
           },
         },
       },
@@ -156,7 +164,7 @@ const spec = computed(() => {
         from: { data: "bars" },
         encode: {
           enter: {
-            x: { field: "x2", offset: 5 },
+            x: { scale: "xscale", value: props.expected, offset: 5 },
             y: { field: "y", offset: { field: "height", mult: 0.5 } },
             fill: { value: COLORS.dark },
             align: { value: "left" },
@@ -179,7 +187,7 @@ const spec = computed(() => {
             align: { value: "right" },
             baseline: { value: "middle" },
             text: {
-              signal: "format(datum.datum.pct, '.0%') + ' vaccinated'",
+              signal: "format(datum.datum.pct, '.0%')",
             },
           },
         },


### PR DESCRIPTION
Fixed text cutoff issue in the gap chart.

 - Fixes #200

### Changes:

 - 'X% vaccinated' changed to just 'X%'
 - Dose Gap text moved to the right of the expected line.
 - X-Domain now computed based on the expected value.
 - Added beige highlight when hovering over the dose gap rectangle to emphasize the gap.

### Images

Vaccine dose gap chart with the adjusted features (sliding domain, moved text, etc).

![Vaccine dose gap chart with the adjusted features.](https://user-images.githubusercontent.com/35873035/235247685-2a1cbd21-d900-4915-943e-41d89e6f6a59.png)

Vaccine dose gap chart showing the hover highlight.

![Vaccine dose gap chart showing the hover highlight](https://user-images.githubusercontent.com/35873035/235248141-f6499e68-e009-4921-8619-7da035fd34a1.png)

