### PR TITLE
fix: Cold Spot Map Mobile Scroll Disabled

### DIFF
--- a/src/components/dashboard/ColdMap.vue
+++ b/src/components/dashboard/ColdMap.vue
@@ -126,10 +126,6 @@ const spec = computed(() => {
             events: "@cluster_groups:mousedown",
             update: `activeGeography === datum.properties.cluster_id ? ${NULL_CLUSTER.cluster_id} : datum.properties.cluster_id`,
           },
-          {
-            events: "@cluster_groups:touchstart",
-            update: `activeGeography === datum.properties.cluster_id ? ${NULL_CLUSTER.cluster_id} : datum.properties.cluster_id`,
-          },
         ],
       },
     ],


### PR DESCRIPTION
Removed the `touchstart` listener on the Cold Map to enable mobile scroll.

 - Fixes #187

~~**Disclaimer**: This works on the desktop simulated mobile environment, but I want to have GitHub open a test site with this PR so that I can verify this on my phone.~~

**Edit**: This works on my andoid phone! I'm going to open the PR officially now. If someone wouldn't mind testing this on an iOS device to, that would be wonderful.