### PR TITLE
fix: Gap Chart Mobile UI

### DIFF
--- a/src/components/dashboard/GapChart.vue
+++ b/src/components/dashboard/GapChart.vue
@@ -23,6 +23,11 @@ const spec = computed(() => {
     description: "Bar chart showing the gap in vaccinations by race",
     background: "transparent",
     padding: { left: 0, top: 0, right: 0, bottom: -1 },
+    autosize: {
+      type: "fit",
+      resize: true,
+      contains: "padding",
+    },
 
     data: [
       {
@@ -38,7 +43,7 @@ const spec = computed(() => {
     scales: [
       {
         name: "xscale",
-        domain: [0, Math.min(props.expected * 1.25, 1)],
+        domain: [0, Math.min(props.expected * 1.5, 1)],
         range: "width",
       },
       {
@@ -170,8 +175,7 @@ const spec = computed(() => {
             align: { value: "left" },
             baseline: { value: "middle" },
             text: {
-              signal:
-                "datum.datum.gap > 0 ? datum.datum.gap + ' dose gap' : ''",
+              signal: "datum.datum.gap > 0 ? datum.datum.gap + ' doses' : ''",
             },
           },
         },


### PR DESCRIPTION
Based on our discussion last week, these changes were made to the Gap Chart to improve usability on mobile:

 - Change "dose gap" text to just "doses".
 - Increase width of the graph to 150% of the state average.
 - Include Vega auto-sizing code snippet.

Example gap chart on a simulated iPhone (375px width):

<img width="369" alt="Example gap chart on a simulated iPhone" src="https://user-images.githubusercontent.com/35873035/236873634-d0716c50-32de-41ba-b8d4-07fce27f3d63.png">


Fixes #206