### PR TITLE
fix: View Latest Data Single Click To Reset Date

### DIFF
--- a/src/views/datasets/booster-gap/index.vue
+++ b/src/views/datasets/booster-gap/index.vue
@@ -6,7 +6,7 @@
     </p>
     <p v-else class="update-date">
       Archived data from {{ prettyDate(currentDate) }} -
-      <router-link :to="path">View latest data</router-link>
+      <router-link :to="linkToCurrentData">View latest data</router-link>
     </p>
     <div class="vertical-spacing" />
     <Dashboard
@@ -44,6 +44,10 @@ useQueryParam({
 
 const route = useRoute();
 const { path } = route;
+const linkToCurrentData = {
+  path,
+  query: { date: currentDate.value },
+};
 
 const scrollRef = ref(null);
 const handleDateChange = (newDate) => {

--- a/src/views/datasets/vaccine-gap/index.vue
+++ b/src/views/datasets/vaccine-gap/index.vue
@@ -6,7 +6,7 @@
     </p>
     <p v-else class="update-date">
       Archived data from {{ prettyDate(currentDate) }} -
-      <router-link :to="path">View latest data</router-link>
+      <router-link :to="linkToCurrentData">View latest data</router-link>
     </p>
     <div class="vertical-spacing" />
     <Dashboard
@@ -44,6 +44,10 @@ useQueryParam({
 
 const route = useRoute();
 const { path } = route;
+const linkToCurrentData = {
+  path,
+  query: { date: currentDate.value },
+};
 
 const scrollRef = ref(null);
 const handleDateChange = (newDate) => {


### PR DESCRIPTION
Changed the "view latest data" link to explicitly set the date query parameter.

 - Fixes #179 

**Note:** ~~I *think* this is fixed on the Vaccine Gap page?~~ (It's both now actually 🎉 ) If someone could double check the behavior on this to (a) make sure I understood this correctly and (b) to double check I actually did fix it 😅.