### PR TITLE
fix: map click zoom

### DIFF
--- a/src/components/dashboard/ColdMap.vue
+++ b/src/components/dashboard/ColdMap.vue
@@ -159,6 +159,10 @@ const spec = computed(() => {
             events: "@cluster_groups:mousedown",
             update: `activeGeography === datum.properties.cluster_id ? ${NULL_CLUSTER.cluster_id} : datum.properties.cluster_id`,
           },
+          {
+            events: "@cluster_groups:touchend",
+            update: `activeGeography === datum.properties.cluster_id ? ${NULL_CLUSTER.cluster_id} : datum.properties.cluster_id`,
+          },
         ],
       },
     ],


### PR DESCRIPTION
Bug Reproduce: Click a region then click zoom on mobile --> it should have zoomed to the region but instead clears

Solution: Slightly alters https://github.com/pph-collective/signal-app/pull/207 to use `touchend`